### PR TITLE
Add maximum number of allowed subscriptions for a Job

### DIFF
--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -8,3 +8,8 @@ class AlreadySubscribedAPIException(APIException):
     def __init__(self, subs, *args, **kwargs):
         detail = f"User already subscribed with date {subs.date_created}"
         super().__init__(detail=detail, *args, **kwargs)
+
+
+class JobFullAPIException(APIException):
+    default_detail = "Job has reached limit of subscriptions."
+    status_code = status.HTTP_409_CONFLICT

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -30,6 +30,9 @@ class Job(models.Model):
         null=True,
         blank=True,
     )
+    max_num_subs = models.PositiveIntegerField(
+        default=0,
+    )
     subscriptions = models.ManyToManyField(
         Candidate,
         through="Subscription",

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from core.models import Job, Subscription
 from core.serializers import UserSerializer, JobSerializer
-from core.exceptions import AlreadySubscribedAPIException
+from core.exceptions import AlreadySubscribedAPIException, JobFullAPIException
 from core.throttling import SubscriptionRateThrottle
 
 
@@ -35,14 +35,17 @@ class JobViewSet(viewsets.ModelViewSet):
     @action(methods=["GET"], detail=True)
     def apply(self, request, pk=None):
         job = self.get_object()
-        subs, created = Subscription.objects.get_or_create(
-            job=job,
-            candidate=request.user,
-        )
-        if created:
-            return Response({"detail": "OK"})
+        if job.max_num_subs != 0 and job.subscriptions.count() < job.max_num_subs:
+            subs, created = Subscription.objects.get_or_create(
+                job=job,
+                candidate=request.user,
+            )
+            if created:
+                return Response({"detail": "OK"})
+            else:
+                raise AlreadySubscribedAPIException(subs)
         else:
-            raise AlreadySubscribedAPIException(subs)
+            raise JobFullAPIException
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Note that if many `apply` requests arrive in a short period of time, this may lead to undesired behavior due to race conditions (more than `max_num_subs` Candidates subribed to the same Job).